### PR TITLE
Removing fs dependency as it is part of Node.js core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-pre-commit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "You can run the pre-commit with any build tool (Gulp, Grunt etc..) and it will ignore all the **unstaged changes** that wasn't added to the git index (using the command ```git add```).",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "del": "2.2.0",
-    "fs": "0.0.2",
     "gulp": "3.9.1",
     "gulp-chmod": "1.3.0",
     "gulp-debug": "2.1.2",


### PR DESCRIPTION
Apparently the 'fs' package is now part of the npm core, and is no longer required for import.
npm/npm#13743
