### PR TITLE
Make pre-commit script running on Ubuntu bash

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -6,7 +6,7 @@
 TEST=%PATH%
 
 # Not in Windows
-if [ "$TEST" == "%PATH%" ]; then
+if [ "$TEST" = "%PATH%" ]; then
   TEST=$PATH:/usr/local/bin:/usr/local/sbin
 fi;
 


### PR DESCRIPTION
`==` doesn't seem a valid operation in Ubuntu's bash.

Fixes #36